### PR TITLE
ci: use rpsec <3.10 for ruby 3.x compatibility

### DIFF
--- a/dimelo_ccp_api.gemspec
+++ b/dimelo_ccp_api.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency('activemodel', '>= 4.2')
   s.add_dependency('faraday', '< 2')
   s.add_development_dependency('rake')
-  s.add_development_dependency('rspec', '~> 3.0')
+  s.add_development_dependency('rspec', '~> 3.0', '< 3.10')
 end


### PR DESCRIPTION
With rspec > 3.9 and ruby 3.x there is an error:

```
Failures:

  1) Dimelo::CCP::API::Connection.from_uri should infer :use_ssl => true from the scheme
     Failure/Error: pool[uri_key(uri)] ||= new(uri.to_s, options)
     
       #<Dimelo::CCP::API::Connection (class)> received :new with unexpected arguments
         expected: ("https://example.com:8080/foo/bar?egg=spam", {:use_ssl=>true})
              got: ("https://example.com:8080/foo/bar?egg=spam", {:use_ssl=>true})
       Diff:
       
     # ./lib/dimelo/ccp/api/connection.rb:11:in `from_uri'
     # ./spec/lib/dimelo/ccp/api/connection_spec.rb:12:in `block (3 levels) in <top (required)>'

  2) Dimelo::CCP::API::Connection.from_uri should infer :use_ssl => false from the scheme
     Failure/Error: pool[uri_key(uri)] ||= new(uri.to_s, options)
     
       #<Dimelo::CCP::API::Connection (class)> received :new with unexpected arguments
         expected: ("http://example.com:8080/foo/bar?egg=spam", {:use_ssl=>false})
              got: ("http://example.com:8080/foo/bar?egg=spam", {:use_ssl=>false})
       Diff:
       
     # ./lib/dimelo/ccp/api/connection.rb:11:in `from_uri'
     # ./spec/lib/dimelo/ccp/api/connection_spec.rb:17:in `block (3 levels) in <top (required)>'

  3) Dimelo::CCP::API::Connection.from_uri should support http options
     Failure/Error: pool[uri_key(uri)] ||= new(uri.to_s, options)
     
       #<Dimelo::CCP::API::Connection (class)> received :new with unexpected arguments
         expected: ("http://example.com:8080/foo/bar?egg=spam", {:timeout=>80, :use_ssl=>false})
              got: ("http://example.com:8080/foo/bar?egg=spam", {:timeout=>80, :use_ssl=>false})
       Diff:
       
     # ./lib/dimelo/ccp/api/connection.rb:11:in `from_uri'
     # ./spec/lib/dimelo/ccp/api/connection_spec.rb:22:in `block (3 levels) in <top (required)>'
```

I can't explain it yet but forcing rspec < 3.9 solves the issue